### PR TITLE
Fixed unknown constant error on Xcode 6b3

### DIFF
--- a/SwiftStatusBarApplication/AppDelegate.swift
+++ b/SwiftStatusBarApplication/AppDelegate.swift
@@ -20,7 +20,8 @@ class AppDelegate: NSObject, NSApplicationDelegate
         let bar = NSStatusBar.systemStatusBar();
         
         //statusItemWithLength expects CGFloat; NSVariableStatusItemLength is CInt
-        let length = CDouble(NSVariableStatusItemLength);
+        // NSVariableStatusItemLength is throwing a linker error on Xcode 6b3
+        let length = CDouble(-1);
         
         let item = bar.statusItemWithLength(length);
         


### PR DESCRIPTION
Thanks for the nice project!

I was having a small issue however on the latest Xcode 6b3:

```
Undefined symbols for architecture x86_64:
  "_NSVariableStatusItemLength", referenced from:
      __TFC25SwiftStatusBarApplication11AppDelegatecfMS0_FT_S0_ in AppDelegate.o
ld: symbol(s) not found for architecture x86_64
```

Not sure if this is an Xcode bug or something dumb I'm doing, but NSVariableStatusItemLength is no longer available on the latest build. Putting the constant value here is a quick work-around until this gets fixed, but is definitely not the right long-term fix.

This is more just a note for anyone else who may stumble on this issue—feel free to reject/pull as you see fit.
